### PR TITLE
Add animations to cards

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -104,23 +104,22 @@ Using our new design, we're going to rework our homepage, making it more enjoyab
   - [x] Setup basic vertical (grid?) layout, check vertical line
   - [x] Use Card component for experiences
 
-- [ ] Deploy full basic homepage
+- [x] Deploy full basic homepage
 
 #### Animation & interaction
 
-Now that out page is looking much better, we're going to add some animations and interaction, to better improve the user experience, and display more interesting skills.
+Now that our page is looking much better, we're going to add some animations and interaction, to better improve the user experience, and display more interesting skills.
 
-- [ ] Skills section:
+- [x] Skills section:
 
-  - [ ] Add slide-in bottom-to-top animation for cards, with opacity change.
-  - [ ] Make the cards appear with different delays.
+  - [x] Card animations: Slide-in from bottom with fade-in while appearing.
+  - [x] Delay the animation on desktop so the cards don't appear all at once.
+  - [x] Make sure the animation only happens once: the cards stay after appearing.
 
-- [ ] Experience section:
+- [x] Experience section:
 
-  - [ ] Switch the layout to vertical
-  - [ ] Develop the animated vertical chronological line: needs a circle or arrow when reaching experience card, appears on scroll down, and changes color when scrolling past the experience card. The color needs to change back if scrolling up, but must not disappear.
-  - [ ] Develop the slide-in animation for the cards: either bottom-to-top, or side-to-center (kind of) with opacity change.
-  - [ ] Must appear on scroll and stay.
+  - [x] Card animations: slide-in from side with fade-in while appearing.
+  - [x] Timeline: make the line & circles change color or appear with scroll.
 
 - [ ] Contact section:
 
@@ -131,8 +130,6 @@ Now that out page is looking much better, we're going to add some animations and
   - [ ] Setup form validation with Zod
   - [ ] Setup email sender
   - [ ] Double-check mobile behaviour
-
-- [ ] Merge and deploy
 
 ## ROADMAP - DONE
 
@@ -167,15 +164,15 @@ Now that out page is looking much better, we're going to add some animations and
 
 Not linked to any roadmap, but to do when/if relevant or necessary.
 
-- [ ] Theme - Setup dark mode integration (+ colored themes)
-- [ ] Component - Add a scroll-to-top button
-- [ ] Component - Change language switcher to a `Select` component
-- [ ] Internationalization - Add translations for accessibility & common items (links, buttons)
-- [ ] Routes - Upon adding new pages, reorganise routes
-- [ ] Architecture - Use `FSD` ([Feature-Slided Design](https://feature-sliced.design/docs/guides/tech/with-nextjs#app-router)) for better clarity & scaling
-- [ ] Internationalization - Separate dictionaries in multiple files when starting projects
-- [ ] Theme - When creating project, check if relevant to use style files (.css + tailwind.config.ts) specific to the project's route to override generic style (layout, component, fonts etc.).
 - [ ] Markdown - Update files & formatting, add table of contents (cf. extension)
+- [ ] Theme - Setup dark mode integration (+ colored themes?)
+- [ ] Component - Change language switcher to a `Select` component (if theme switcher is onClick)
+- [ ] Component - Add a scroll-to-top button
+- [ ] Architecture - Use `FSD` ([Feature-Slided Design](https://feature-sliced.design/docs/guides/tech/with-nextjs#app-router)) for better clarity & scaling
+- [ ] Routes - Upon adding new pages, reorganise routes (& reorganize `/data` & `/utils`)
+- [ ] Internationalization - Separate dictionaries in multiple files when starting projects
+- [ ] Internationalization - Add translations for accessibility & common items (links, buttons)
+- [ ] Theme - When creating project, check if relevant to use style files (.css + tailwind.config.ts) specific to the project's route to override generic style (layout, component, fonts etc.).
 
 ## FUTURE ROADMAP & IDEAS
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,7 +42,7 @@
         "hero": {
           "salutation": "Hello ! I'm Mathieu,",
           "title": "I develop modern and optimized web applications",
-          "description": "As an experienced <jobTitle>FRONEND DEVELOPER</jobTitle>, I create user-friendly <tech>React.js</tech> & <tech>TypeScript</tech> applications, with the goal of becoming Fullstack developer."
+          "description": "As an experienced <jobTitle>FRONTEND DEVELOPER</jobTitle>, I create user-friendly <tech>React.js</tech> & <tech>TypeScript</tech> applications, with the goal of becoming Fullstack developer."
         },
         "skills": {
           "title": "Skills",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "prettier": "~3.4.2",
         "prettier-plugin-tailwindcss": "~0.6.9",
         "react-icons": "~5.4.0",
+        "react-intersection-observer": "^9.14.1",
         "tailwind-merge": "~2.5.5",
         "tailwindcss": "~3.4.16",
         "tailwindcss-animate": "~1.0.7",
@@ -5555,6 +5556,22 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.14.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.14.1.tgz",
+      "integrity": "sha512-k1xIUn3sCQi3ugNeF64FJb3zwve5mcetvAUR9JazXeOmtap4IP2evN8rs+yf6SQ7F1QydsOGiqTmt+lySKZ9uA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -44,6 +44,7 @@
     "prettier": "~3.4.2",
     "prettier-plugin-tailwindcss": "~0.6.9",
     "react-icons": "~5.4.0",
+    "react-intersection-observer": "~9.14.1",
     "tailwind-merge": "~2.5.5",
     "tailwindcss": "~3.4.16",
     "tailwindcss-animate": "~1.0.7",

--- a/src/components/experiences-block/experience-card.tsx
+++ b/src/components/experiences-block/experience-card.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { cn } from '@/utils/tailwindcss';
+
+import { Experience } from './';
+
+interface Props {
+  item: Experience;
+  isViewportMd: boolean;
+}
+const ExperienceCard: React.FC<Props> = ({ item, isViewportMd }) => {
+  const { ref, inView } = useInView({ triggerOnce: true, threshold: isViewportMd ? 1 : 0.3 });
+
+  return (
+    <div ref={ref} className="group flex items-center justify-between md:justify-normal md:odd:flex-row-reverse">
+      <div
+        id="icon"
+        className={cn(
+          'border-border-white flex size-6 shrink-0 items-center justify-center rounded-full bg-accent shadow-md md:order-1 md:group-odd:-translate-x-7 md:group-even:translate-x-7',
+          inView ? 'opacity-1 transition-opacity delay-1000 duration-1000 ease-out' : 'opacity-0'
+        )}
+      />
+
+      <article
+        className={cn(
+          'relative w-[calc(100%-2.5rem)] md:w-[calc(50%-2.5rem)]',
+          inView
+            ? 'animate-in fade-in slide-in-from-right duration-1500 md:group-odd:slide-in-from-right md:group-even:slide-in-from-left'
+            : 'opacity-0'
+        )}
+      >
+        <div
+          className={cn(
+            'card space-y-4',
+            'before:absolute before:left-0 before:top-1/2 before:size-5 before:-translate-x-1/2 before:-translate-y-1/2 before:rotate-45 before:border-b before:border-l before:border-grey-border before:bg-white md:group-even:before:left-full md:group-even:before:border-b-0 md:group-even:before:border-l-0 md:group-even:before:border-r md:group-even:before:border-t'
+          )}
+        >
+          <div>
+            <p className="title-card">{item.title}</p>
+            <p className="body-muted">
+              {item.dates} | <span className="font-semibold">{item.business}</span>, {item.location}
+            </p>
+          </div>
+          <p>{item.description}</p>
+        </div>
+      </article>
+    </div>
+  );
+};
+
+export default ExperienceCard;

--- a/src/components/experiences-block/index.tsx
+++ b/src/components/experiences-block/index.tsx
@@ -1,9 +1,14 @@
+'use client';
+
 import { useTranslations } from 'next-intl';
 import React from 'react';
 
+import useViewportBreakpoint from '@/hooks/use-viewport-breakpoint';
 import { cn } from '@/utils/tailwindcss';
 
-interface Experience {
+import ExperienceCard from './experience-card';
+
+export interface Experience {
   title: string;
   business: string;
   dates: string;
@@ -13,6 +18,7 @@ interface Experience {
 
 const ExperiencesBlock: React.FC = () => {
   const t = useTranslations('Pages.Homepage.sections.experiences.cards');
+  const isViewportMd = useViewportBreakpoint('md');
 
   const experienceItems: Experience[] = [
     {
@@ -33,46 +39,22 @@ const ExperiencesBlock: React.FC = () => {
       title: t('humanBooster.title'),
       business: t('humanBooster.business'),
       dates: '2020-2021',
-      location: 'St-Etienne',
+      location: 'St-Étienne',
       description: t('humanBooster.description'),
     },
   ];
 
   return (
-    <div className="mt-20 grid grid-cols-1 grid-rows-3 gap-y-4 md:grid-cols-experience">
-      {experienceItems.map((item: Experience, index) => (
-        <React.Fragment key={item.business}>
-          <div
-            className={cn(
-              'md:flex md:flex-row md:items-center',
-              index % 2 === 0 ? 'md:col-start-1' : 'md:col-start-3 md:flex-row-reverse'
-            )}
-          >
-            <article className={cn('card z-10 min-w-[15rem] space-y-4 sm:max-md:hover:scale-[1.02]')}>
-              <div>
-                <p className="title-card">{item.title}</p>
-                <p className="body-muted">
-                  {item.dates} | <span className="font-semibold">{item.business}</span>, {item.location}
-                </p>
-              </div>
-              <p>{item.description}</p>
-            </article>
-
-            <div id={`line-${index}`} className="relative hidden h-[0.125rem] w-8 bg-accent md:block">
-              <div
-                className={cn(
-                  'absolute top-1/2 size-4 -translate-y-1/2 rounded-full bg-accent',
-                  index % 2 === 0 ? 'left-full -translate-x-1/2' : 'left-0 -translate-x-1/2'
-                )}
-              />
-            </div>
-          </div>
-
-          <div id="empty-placeholder-grid" className={cn('hidden md:block', index % 2 === 0 ? '' : 'md:hidden')} />
-        </React.Fragment>
+    <div
+      id="timeline-container"
+      className={cn(
+        'relative mt-20 space-y-4',
+        'before:absolute before:inset-0 before:ml-3 before:h-full before:w-0.5 before:-translate-x-px before:bg-gradient-to-b before:from-transparent before:via-accent before:to-transparent md:before:mx-auto md:before:translate-x-0'
+      )}
+    >
+      {experienceItems.map((item: Experience, index: number) => (
+        <ExperienceCard key={index} item={item} isViewportMd={isViewportMd} />
       ))}
-
-      <div id="vertical-line" className="col-start-2 row-span-3 row-start-1 hidden h-full w-full bg-accent md:block" />
     </div>
   );
 };

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import React, { useEffect, useState } from 'react';
 
 import LocalSwitcher from '@/components/locale-switcher';
+import useViewportBreakpoint from '@/hooks/use-viewport-breakpoint';
 import { Link, usePathname } from '@/i18n/routing';
 import { cn } from '@/utils/tailwindcss';
 import { INavRouteItem } from '@/utils/types';
@@ -18,6 +19,7 @@ const Header: React.FC<Props> = ({ navItems }) => {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const pathname = usePathname();
   const tHeader = useTranslations('Layout.Header');
+  const isViewportMd = useViewportBreakpoint('md');
 
   const handleBurgerMenu = (state: 'open' | 'close') => {
     setIsMenuOpen(state === 'open');
@@ -26,6 +28,11 @@ const Header: React.FC<Props> = ({ navItems }) => {
   const toggleBurgerMenu = () => {
     setIsMenuOpen(prev => !prev);
   };
+
+  // On window resize, if mobile menu was open, close it when using desktop layout (without it, would prevent from scrolling)
+  useEffect(() => {
+    if (isViewportMd) setIsMenuOpen(false);
+  }, [isViewportMd]);
 
   // Disables scrolling when mobile menu is open
   useEffect(() => {

--- a/src/components/section-block/index.tsx
+++ b/src/components/section-block/index.tsx
@@ -32,7 +32,7 @@ const SectionWrapper: React.FC<Props> = ({
     <section
       id={id}
       className={cn(
-        'bg-background',
+        'overflow-clip bg-background',
         first ? 'section-py-first' : 'section-py',
         full && 'section-full',
         dark && 'bg-primary'

--- a/src/components/skills-block/index.tsx
+++ b/src/components/skills-block/index.tsx
@@ -6,7 +6,11 @@ import { FaChartLine, FaReact } from 'react-icons/fa';
 import { GoMultiSelect } from 'react-icons/go';
 import { RiTeamLine } from 'react-icons/ri';
 
-interface Skill {
+import useViewportBreakpoint from '@/hooks/use-viewport-breakpoint';
+
+import SkillCard from './skill-card';
+
+export interface Skill {
   title: string;
   description: string;
   icon: ReactElement;
@@ -14,6 +18,7 @@ interface Skill {
 
 const SkillsBlock: React.FC = () => {
   const t = useTranslations('Pages.Homepage.sections.skills.cards');
+  const isViewportLg = useViewportBreakpoint('lg');
 
   const skillsItem: Skill[] = [
     {
@@ -39,57 +44,12 @@ const SkillsBlock: React.FC = () => {
   ];
 
   return (
-    <div className="grid grid-cols-1 gap-5 py-20 sm:grid-cols-2 lg:grid-cols-4">
-      {skillsItem.map((item: Skill) => (
-        <article key={item.title} className="card min-w-[15rem] space-y-7">
-          <div>{item.icon}</div>
-          <div className="space-y-4">
-            <p className="title-card">{item.title}</p>
-            <p>{item.description}</p>
-          </div>
-        </article>
+    <div className="my-20 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4">
+      {skillsItem.map((item: Skill, index) => (
+        <SkillCard key={index} item={item} index={index} isViewportLg={isViewportLg} />
       ))}
     </div>
   );
 };
-
-// TODO: When setting up animations, use this SkillCard component
-// const SkillCard: React.FC<Skill> = ({ title, description, icon }) => {
-//   const [isVisible, setIsVisible] = useState<boolean>(false);
-//   const ref = useRef<HTMLDivElement>(null);
-
-//   useEffect(() => {
-//     const observer = new IntersectionObserver(
-//       ([entry]) => {
-//         if (entry.isIntersecting) {
-//           setIsVisible(true);
-//         }
-//       },
-//       { threshold: 0.8 }
-//     );
-
-//     if (ref.current) {
-//       observer.observe(ref.current);
-//     }
-
-//     return () => observer.disconnect();
-//   }, []);
-
-//   return (
-//     <article
-//       ref={ref}
-//       className={cn(
-//         'card min-w-[15rem] space-y-7 duration-1000',
-//         isVisible ? 'animate-in fade-in slide-in-from-bottom' : 'opacity-0'
-//       )}
-//     >
-//       <div>{icon}</div>
-//       <div className="space-y-4">
-//         <p className="title-card">{title}</p>
-//         <p>{description}</p>
-//       </div>
-//     </article>
-//   );
-// };
 
 export default SkillsBlock;

--- a/src/components/skills-block/skill-card.tsx
+++ b/src/components/skills-block/skill-card.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { cn } from '@/utils/tailwindcss';
+
+import { Skill } from './';
+
+interface Props {
+  item: Skill;
+  index: number;
+  isViewportLg: boolean;
+}
+
+const SkillCard: React.FC<Props> = ({ item, index, isViewportLg }) => {
+  const { ref, inView } = useInView({ triggerOnce: true, threshold: 0.3 });
+  const [hasLoaded, setHasLoaded] = useState<boolean>(false);
+
+  // Adds a '1s' delay between each cards using the item's index number.
+  useEffect(() => {
+    if (isViewportLg) {
+      const activateAnimation = setTimeout(() => {
+        if (inView) setHasLoaded(true);
+      }, index * 1000);
+
+      return () => clearTimeout(activateAnimation);
+    } else {
+      if (inView) setHasLoaded(true);
+    }
+  }, [inView, index, isViewportLg]);
+
+  return (
+    <article
+      ref={ref}
+      className={cn(hasLoaded ? 'duration-1000 animate-in fade-in slide-in-from-bottom' : 'opacity-0')}
+    >
+      <div className="card space-y-4">
+        <p className="title-card flex flex-row items-center justify-between gap-4">
+          {item.title}
+          {item.icon}
+        </p>
+        <p>{item.description}</p>
+      </div>
+    </article>
+  );
+};
+
+export default SkillCard;

--- a/src/hooks/use-viewport-breakpoint.ts
+++ b/src/hooks/use-viewport-breakpoint.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+import { EBreakpoints, IBreakpoint } from '@/utils/tailwindcss';
+
+/**
+ * Checks if the current viewport's width corresponds to the chosen breakpoint.
+ * @param breakpoint Minimum width to compare the viewport's, uses Tailwind CSS's breakpoint values.
+ * @returns A boolean that confirms if the current viewport corresponds to the breakpoint (true = is wider).
+ */
+const useViewportBreakpoint = (breakpoint: IBreakpoint): boolean => {
+  const [isMediaMatch, setIsMediaMatch] = useState<boolean>(
+    () => typeof window !== 'undefined' && window.matchMedia(`(min-width: ${EBreakpoints[breakpoint]})`).matches
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQueryList = window.matchMedia(`(min-width: ${EBreakpoints[breakpoint]})`);
+    const handleMediaQueryChange = (e: MediaQueryListEvent) => setIsMediaMatch(e.matches);
+
+    setIsMediaMatch(mediaQueryList.matches);
+
+    mediaQueryList.addEventListener('change', handleMediaQueryChange);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', handleMediaQueryChange);
+    };
+  }, [breakpoint]);
+
+  return isMediaMatch;
+};
+
+export default useViewportBreakpoint;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -113,7 +113,7 @@
   }
 
   .card {
-    @apply h-full w-full rounded-lg border bg-white p-5 shadow-md transition-all hover:scale-105 hover:shadow-lg;
+    @apply h-full w-full rounded-lg border border-grey-border bg-white p-5 shadow-md transition-all hover:scale-[1.02] hover:shadow-lg;
   }
 }
 

--- a/src/utils/tailwindcss.ts
+++ b/src/utils/tailwindcss.ts
@@ -1,6 +1,15 @@
 import clsx, { ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+export type IBreakpoint = 'sm' | 'md' | 'lg' | 'xl';
+
+export enum EBreakpoints {
+  sm = '576px',
+  md = '768px',
+  lg = '1024px',
+  xl = '1280px',
+}
+
 export function cn(...args: ClassValue[]) {
   return twMerge(clsx(args));
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -65,6 +65,9 @@ const config: Config = {
       backdropBlur: {
         xs: '2px',
       },
+      animationDuration: {
+        '1500': '1.5s',
+      },
       // Use keyframes and animations for reusable "fade" and "slide" animations
       // keyframes:{},
       // animations: {},


### PR DESCRIPTION
Added animations to Skill & Experience cards to make these sections more appealing:
- Added `slide-in` & `fade-in` animation for cards
- Setup small delay so Skill cards appear one-by-one
- Setup timeline with card animation for Experience section
- Setup a hook to check if the viewport corresponds to a specific breakpoint (or wider)
- Fixed an issue with mobile navigation's overflow-hidden preventing users from scrolling if they resized their viewport while the menu was opened